### PR TITLE
Add TapCommandBehavior and BaseAttachable

### DIFF
--- a/Library/PhantomLib/Behaviors/TapCommandBehavior.cs
+++ b/Library/PhantomLib/Behaviors/TapCommandBehavior.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Windows.Input;
+using Xamarin.Forms;
+
+namespace PhantomLib.Behaviors
+{
+    public class TapCommandBehavior : Behavior<View>
+    {
+        private TapGestureRecognizer _tapGestureRecognizer;
+        public View AssociatedView { get; private set; }
+
+        public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(TapCommandBehavior), propertyChanged: OnCommandChanged);
+        public ICommand Command
+        {
+            get { return (ICommand)GetValue(CommandProperty); }
+            set { SetValue(CommandProperty, value); }
+        }
+
+        private static void OnCommandChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            if (!(bindable is TapCommandBehavior tapCommandBehavior) || tapCommandBehavior._tapGestureRecognizer == null)
+                return;
+
+            tapCommandBehavior._tapGestureRecognizer.Command = tapCommandBehavior.Command;
+        }
+
+        public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(TapCommandBehavior), propertyChanged: OnCommandParameterChanged);
+        public object CommandParameter
+        {
+            get { return (object)GetValue(CommandParameterProperty); }
+            set { SetValue(CommandParameterProperty, value); }
+        }
+
+        private static void OnCommandParameterChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            if (!(bindable is TapCommandBehavior tapCommandBehavior) || tapCommandBehavior._tapGestureRecognizer == null)
+                return;
+
+            tapCommandBehavior._tapGestureRecognizer.CommandParameter = tapCommandBehavior.CommandParameter;
+        }
+
+        protected override void OnAttachedTo(View bindable)
+        {
+            base.OnAttachedTo(bindable);
+
+            AssociatedView = bindable;
+
+            _tapGestureRecognizer = new TapGestureRecognizer()
+            {
+                Command = Command,
+                CommandParameter = CommandParameter
+            };
+
+            bindable.GestureRecognizers.Add(_tapGestureRecognizer);
+
+            bindable.BindingContextChanged += OnBindingContextChanged;
+            BindingContext = bindable.BindingContext;
+        }
+
+        protected override void OnDetachingFrom(View bindable)
+        {
+            base.OnDetachingFrom(bindable);
+
+            bindable.BindingContextChanged -= OnBindingContextChanged;
+
+            bindable.GestureRecognizers.Remove(_tapGestureRecognizer);
+            AssociatedView = null;
+        }
+
+        protected override void OnBindingContextChanged()
+        {
+            base.OnBindingContextChanged();
+
+            _tapGestureRecognizer.Command = Command;
+            _tapGestureRecognizer.CommandParameter = CommandParameter;
+        }
+
+        private void OnBindingContextChanged(object sender, EventArgs e)
+        {
+            BindingContext = AssociatedView.BindingContext;
+        }
+    }
+}

--- a/Library/PhantomLib/Models/BaseAttachable.cs
+++ b/Library/PhantomLib/Models/BaseAttachable.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace PhantomLib.Models
+{
+    /// <summary>
+    /// Base class for <see cref="IAttachable"/> implementations. This abstract
+    /// class has helper methods to raise the <see cref="PropertyChanging"/> and
+    /// <see cref="PropertyChanged"/> events to notify any listeners of property
+    /// changes.
+    /// </summary>
+    public abstract class BaseAttachable : IAttachable
+    {
+        public event PropertyChangedEventHandler PropertyChanged = delegate { };
+        public event PropertyChangingEventHandler PropertyChanging = delegate { };
+
+        /// <summary>
+        /// Sets a property's value and triggers the <see cref="PropertyChanging"/>
+        /// and <see cref="PropertyChanged"/> events.
+        /// </summary>
+        /// <returns><c>true</c>, if the property was changed, <c>false</c> otherwise.</returns>
+        /// <param name="storage">The private backing variable for the property.</param>
+        /// <param name="value">The desired value for the property.</param>
+        /// <param name="propertyName">The property's name (defaults to CallerMemberName).</param>
+        /// <typeparam name="T">The type of the parameter.</typeparam>
+        protected virtual bool SetProperty<T>(ref T storage, T value, [CallerMemberName]string propertyName = null)
+        {
+            if (Equals(storage, value))
+                return false;
+
+            OnPropertyChanging(propertyName);
+
+            storage = value;
+
+            OnPropertyChanged(propertyName);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Raises the <see cref="PropertyChanging"/> event.
+        /// </summary>
+        /// <param name="propertyName">Property name (defaults to CallerMemberName).</param>
+        protected void OnPropertyChanging([CallerMemberName]string propertyName = null)
+        {
+            PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
+        }
+
+        /// <summary>
+        /// Raises the <see cref="PropertyChanged"/> event.
+        /// </summary>
+        /// <param name="propertyName">Property name (defaults to CallerMemberName).</param>
+        protected void OnPropertyChanged([CallerMemberName]string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Library/PhantomLib/Models/IAttachable.cs
+++ b/Library/PhantomLib/Models/IAttachable.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace PhantomLib.Models
+{
+    /// <summary>
+    /// Interface for classes that will notify when their properties are changing
+    /// or have changed.
+    /// </summary>
+    public interface IAttachable : INotifyPropertyChanged, INotifyPropertyChanging
+    {
+
+    }
+}

--- a/Library/PhantomLib/PhantomLib.csproj
+++ b/Library/PhantomLib/PhantomLib.csproj
@@ -18,5 +18,7 @@
     <Folder Include="CustomControls\" />
     <Folder Include="Extensions\" />
     <Folder Include="Utilities\" />
+    <Folder Include="Behaviors\" />
+    <Folder Include="Models\" />
   </ItemGroup>
 </Project>

--- a/PhantomLib.sln
+++ b/PhantomLib.sln
@@ -15,6 +15,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhantomLibSamples", "Sample
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhantomLib.Droid", "Library\PhantomLib.Droid\PhantomLib.Droid.csproj", "{8EC0AB8C-8925-44CB-A275-F3F758B1EEB0}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_docs", "_docs", "{A43672A8-0088-4EFF-9064-48A51E1FEB8B}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ return base.FinishedLaunching(app,  options);
 # Custom controls in this library
 * RoundedFrame - Allows you to spcify which corners of a frame are rounded.
 
+# Behaviors included in this library
+* Tap Command Behavior - Allows you to bind an `ICommand` to be executed when a control is tapped.
+
+# Other helpers included in this library
+* BaseAttachable - Acts as a base class for view-models, with helpers to easily raise `IPropertyChanged` events for properties.
 
 # Sample
 ![Sample Image](Images/Sample2.gif)

--- a/Samples/PhantomLibSamples/MainPage.xaml
+++ b/Samples/PhantomLibSamples/MainPage.xaml
@@ -1,38 +1,81 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
              xmlns:local="clr-namespace:PhantomLib" 
              xmlns:extensions="clr-namespace:PhantomLib.Extensions;assembly=PhantomLib"
              xmlns:controls="clr-namespace:PhantomLib.CustomControls;assembly=PhantomLib"
              xmlns:effects="clr-namespace:PhantomLib.Effects;assembly=PhantomLib"
-             x:Class="PhantomLibSamples.MainPage">
+             xmlns:behaviors="clr-namespace:PhantomLib.Behaviors;assembly=PhantomLib"
+             xmlns:local-vms="clr-namespace:PhantomLibSamples.ViewModels;assembly=PhantomLibSamples"
+             x:Class="PhantomLibSamples.MainPage"
+             ios:Page.UseSafeArea="true">
     <ContentPage.Resources>
         <ResourceDictionary>
             <Style x:Key="LabelStyle" TargetType="Label">
                 <Setter Property="extensions:ViewExtensions.Kerning" Value="10" />
             </Style>
+            <Style x:Key="BoxView_Hr" TargetType="BoxView">
+                <Setter Property="HorizontalOptions" Value="FillAndExpand" />
+                <Setter Property="HeightRequest" Value="1" />
+                <Setter Property="BackgroundColor" Value="Gray" />
+            </Style>
         </ResourceDictionary>
     </ContentPage.Resources>
     <ContentPage.Content>
         <AbsoluteLayout HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
-            <StackLayout VerticalOptions="CenterAndExpand" Margin="10,0">
-                <Label Text="This is an example of Kerning with a letter spacing of 10." HorizontalOptions="Center" Style="{StaticResource LabelStyle}" >
-                    <!--You can set the letters spacing via an extension (as shown in the style) or using the traditional Xamarin effect syntax
-                    <Label.Effects>
-                        <effects:Kerning LetterSpacing="10" />
-                    </Label.Effects>-->
-                </Label>
-                
-                <controls:RoundedFrame  x:Name="InsideLayout" CornerRadius="10" BackgroundColor="Blue" RoundTopLeft="true" RoundTopRight="true"> 
-                    <Label Text="This is a rounded frame with just the top corners rounded" TextColor="White" />
-                </controls:RoundedFrame>
-                 <Image x:Name="LoadingSpinner" Source="loading_spinner_green" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand"
-                        AbsoluteLayout.LayoutBounds="0,0,1,1" AbsoluteLayout.LayoutFlags="All">
-                        <Image.Effects>
-                            <effects:Spinner Duration="700" />
-                        </Image.Effects>
-                    </Image>
-            </StackLayout>
+            <ScrollView>
+                <StackLayout VerticalOptions="CenterAndExpand" Margin="10,0">
+                    <StackLayout>
+                        <Label Text="Kerning Effect" FontSize="Large" />
+                        <Label Text="This is an example of Kerning with a letter spacing of 10." HorizontalOptions="Center" Style="{StaticResource LabelStyle}" >
+                            <!--You can set the letters spacing via an extension (as shown in the style) or using the traditional Xamarin effect syntax
+                            <Label.Effects>
+                                <effects:Kerning LetterSpacing="10" />
+                            </Label.Effects>-->
+                        </Label>
+                    </StackLayout>
+                    <BoxView Style="{StaticResource BoxView_Hr}" />
+                        
+                    <StackLayout>
+                        <Label Text="Rounded Frame" FontSize="Large" />
+                        <controls:RoundedFrame CornerRadius="10" BackgroundColor="Blue" RoundTopLeft="true" RoundTopRight="true"> 
+                            <Label Text="This is a rounded frame with just the top corners rounded" TextColor="White" />
+                        </controls:RoundedFrame>
+                    </StackLayout>
+                    <BoxView Style="{StaticResource BoxView_Hr}" />
+                    
+                    <StackLayout>
+                        <Label Text="Spinner Effect" FontSize="Large" />
+                        <Image x:Name="LoadingSpinner" Source="loading_spinner_green" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
+                            <Image.Effects>
+                                <effects:Spinner Duration="700" />
+                            </Image.Effects>
+                        </Image>
+                    </StackLayout>
+                    <BoxView Style="{StaticResource BoxView_Hr}" />
+                    
+                    <StackLayout BackgroundColor="Aqua" Padding="10">
+                        <StackLayout.BindingContext>
+                            <local-vms:TapCommandBehaviorViewModel />
+                        </StackLayout.BindingContext>
+                        <StackLayout.Behaviors>
+                            <!--
+                            The TapCommandBehavior has bindable properties for Command and Command Parameter.
+                            This instance has a binding to ShowAlert for its command (from the binding context)
+                            and a binding to the Entry's text value for its command parameter.
+                            Tapping anywhere in the StackLayout will trigger an alert with the body that you write in the Entry.
+                            -->
+                            <behaviors:TapCommandBehavior Command="{Binding DisplayAlert}" CommandParameter="{Binding Text, Source={x:Reference _entryTapCommandValue}}" />
+                        </StackLayout.Behaviors>
+                        <Label Text="Tap Command Behavior" FontSize="Large" />
+                        <Entry x:Name="_entryTapCommandValue" Text="Hello, world!" />
+                        <Label Text="Tap anywhere in the Aqua StackLayout to show an alert with the body you enter above." FontSize="Small" />
+                    </StackLayout>
+                    <BoxView Style="{StaticResource BoxView_Hr}" />
+                        
+                </StackLayout>
+            </ScrollView>
         </AbsoluteLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/Samples/PhantomLibSamples/PhantomLibSamples.csproj
+++ b/Samples/PhantomLibSamples/PhantomLibSamples.csproj
@@ -19,5 +19,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Utilities\" />
+    <Folder Include="ViewModels\" />
   </ItemGroup>
 </Project>

--- a/Samples/PhantomLibSamples/ViewModels/TapCommandBehaviorViewModel.cs
+++ b/Samples/PhantomLibSamples/ViewModels/TapCommandBehaviorViewModel.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using PhantomLib.Models;
+using Xamarin.Forms;
+
+namespace PhantomLibSamples.ViewModels
+{
+    public class TapCommandBehaviorViewModel : BaseAttachable
+    {
+        #region bindables
+
+        public ICommand DisplayAlert { get; private set; }
+
+        #endregion
+
+        #region constructor
+
+        public TapCommandBehaviorViewModel()
+        {
+            DisplayAlert = new Command(async (p) => await OnDisplayAlert(p));
+        }
+
+        #endregion
+
+        #region command implementations
+
+        private async Task OnDisplayAlert(object parameter)
+        {
+            await Application.Current.MainPage.DisplayAlert("Here's your secret message:", parameter?.ToString() ?? "<< null >>", "Close");
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This PR introduces two new elements:
- The `BaseAttachable` class, which can be used as a base class for view-models
- The `TapCommandBehavior` class, which can be attached to views to execute a command when the control is tapped

The other, smaller changes include:
- added a `_docs` solution folder with the readme
- updated the readme with a description of the new elements
- adjusted the layout & styles on the main page to delineate between the different elements and 
- added a view model to demonstrate the `TapCommandBehavior`

![Simulator Screen Shot - iPhone Xs - 2019-06-25 at 15 07 48](https://user-images.githubusercontent.com/1892138/60126577-4e6c0c00-975c-11e9-9733-9eda9552ae9a.png)
![Screenshot_1561489800](https://user-images.githubusercontent.com/1892138/60126584-51ff9300-975c-11e9-8372-fe2f954abe47.png)
![Screenshot_1561490250](https://user-images.githubusercontent.com/1892138/60126601-5d52be80-975c-11e9-89fe-9a645c333531.png)
