### PR TITLE
Allow adjustment for safe area insets

### DIFF
--- a/Library/PhantomLib.Droid/PhantomLib.Droid.csproj
+++ b/Library/PhantomLib.Droid/PhantomLib.Droid.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Renderers\RoundedFrame.cs" />
     <Compile Include="Renderers\UltimateEntryRenderer.cs" />
     <Compile Include="Effects\TintImageEffect.cs" />
+    <Compile Include="Utilities\DeviceHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
@@ -68,6 +69,7 @@
     <Folder Include="Resources\drawable\" />
     <Folder Include="Effects\" />
     <Folder Include="Renderers\" />
+    <Folder Include="Utilities\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PhantomLib\PhantomLib.csproj">

--- a/Library/PhantomLib.Droid/Utilities/DeviceHelper.cs
+++ b/Library/PhantomLib.Droid/Utilities/DeviceHelper.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using PhantomLib.Utilities;
+using Xamarin.Forms;
+
+[assembly: Dependency(typeof(PhantomLib.Droid.Utilities.DeviceHelper))]
+namespace PhantomLib.Droid.Utilities
+{
+    public class DeviceHelper : IDeviceHelper
+    {
+        public Thickness GetSafeAreaInsets()
+        {
+            // Android handles safe areas and display cutouts a little differently
+            // than iOS: https://developer.android.com/guide/topics/display-cutout
+            // We don't need to adjust the padding for cutouts because this is
+            // done by the OS.
+            return new Thickness(0);
+        }
+    }
+}

--- a/Library/PhantomLib.iOS/PhantomLib.iOS.csproj
+++ b/Library/PhantomLib.iOS/PhantomLib.iOS.csproj
@@ -56,6 +56,7 @@
     <Folder Include="Resources\" />
     <Folder Include="Effects\" />
     <Folder Include="Renderers\" />
+    <Folder Include="Utilities\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -64,6 +65,7 @@
     <Compile Include="Renderers\RoundedFrameRenderer.cs" />
     <Compile Include="Renderers\UltimateEntryRenderer.cs" />
     <Compile Include="Effects\TintImageEffect.cs" />
+    <Compile Include="Utilities\DeviceHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PhantomLib\PhantomLib.csproj">

--- a/Library/PhantomLib.iOS/Utilities/DeviceHelper.cs
+++ b/Library/PhantomLib.iOS/Utilities/DeviceHelper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+using PhantomLib.Utilities;
+using UIKit;
+using Xamarin.Forms;
+
+[assembly: Dependency(typeof(PhantomLib.iOS.Utilities.DeviceHelper))]
+namespace PhantomLib.iOS.Utilities
+{
+    public class DeviceHelper : IDeviceHelper
+    {
+        private UIEdgeInsets _safeInsets;
+        private bool _safeInsetsRetrieved;
+
+        public Thickness GetSafeAreaInsets()
+        {
+            if (!_safeInsetsRetrieved)
+            {
+                try
+                {
+                    // try to retrieve the safe area insets from the OS
+                    if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
+                    {
+                        var window = UIApplication.SharedApplication.KeyWindow ?? new UIWindow(UIScreen.MainScreen.Bounds);
+                        _safeInsets = window.SafeAreaInsets;
+                    }
+                    else
+                    {
+                        _safeInsets = UIEdgeInsets.Zero;
+                    }
+                }
+                catch
+                {
+                    _safeInsets = UIEdgeInsets.Zero;
+                }
+
+                _safeInsetsRetrieved = true;
+            }
+
+            return new Thickness(_safeInsets.Left, _safeInsets.Top, _safeInsets.Right, _safeInsets.Bottom);
+        }
+    }
+}

--- a/Library/PhantomLib/Extensions/Values.xaml
+++ b/Library/PhantomLib/Extensions/Values.xaml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ResourceDictionary
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="PhantomLib.Extensions.Values">
+</ResourceDictionary>

--- a/Library/PhantomLib/Extensions/Values.xaml.cs
+++ b/Library/PhantomLib/Extensions/Values.xaml.cs
@@ -12,7 +12,7 @@ namespace PhantomLib.Extensions
         public const string Double_SafeAreaInset_R = "Double_SafeAreaInset_R";
         public const string Double_SafeAreaInset_B = "Double_SafeAreaInset_B";
 
-        public const string Thickness_SafeArea = "Thickness_SafeArea";
+        public const string Thickness_SafeAreaInsets = "Thickness_SafeAreaInsets";
 
         public const string Thickness_SafeAreaInsets_V = "Thickness_SafeAreaInsets_V";
         public const string Thickness_SafeAreaInsets_H = "Thickness_SafeAreaInsets_H";
@@ -50,7 +50,7 @@ namespace PhantomLib.Extensions
             this[Double_SafeAreaInset_R] = insets.Right;
             this[Double_SafeAreaInset_B] = insets.Bottom;
 
-            this[Thickness_SafeArea] = insets;
+            this[Thickness_SafeAreaInsets] = insets;
 
             this[Thickness_SafeAreaInsets_V] = new Thickness(0, insets.Top, 0, insets.Bottom);
             this[Thickness_SafeAreaInsets_H] = new Thickness(insets.Left, 0, insets.Right, 0);

--- a/Library/PhantomLib/Extensions/Values.xaml.cs
+++ b/Library/PhantomLib/Extensions/Values.xaml.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using PhantomLib.Utilities;
+using Xamarin.Forms;
+
+namespace PhantomLib.Extensions
+{
+    public partial class Values
+    {
+        public const string Double_SafeAreaInset_L = "Double_SafeAreaInset_L";
+        public const string Double_SafeAreaInset_T = "Double_SafeAreaInset_T";
+        public const string Double_SafeAreaInset_R = "Double_SafeAreaInset_R";
+        public const string Double_SafeAreaInset_B = "Double_SafeAreaInset_B";
+
+        public const string Thickness_SafeArea = "Thickness_SafeArea";
+
+        public const string Thickness_SafeAreaInsets_V = "Thickness_SafeAreaInsets_V";
+        public const string Thickness_SafeAreaInsets_H = "Thickness_SafeAreaInsets_H";
+
+        public const string Thickness_SafeAreaInsets_L = "Thickness_SafeAreaInsets_L";
+        public const string Thickness_SafeAreaInsets_T = "Thickness_SafeAreaInsets_T";
+        public const string Thickness_SafeAreaInsets_R = "Thickness_SafeAreaInsets_R";
+        public const string Thickness_SafeAreaInsets_B = "Thickness_SafeAreaInsets_B";
+
+        public const string Thickness_SafeAreaInsets_LRB = "Thickness_SafeAreaInsets_LRB";
+
+        private readonly IDeviceHelper _deviceHelper;
+
+        public Values()
+            : this(DependencyService.Get<IDeviceHelper>())
+        {
+
+        }
+
+        public Values(IDeviceHelper deviceHelper)
+        {
+            _deviceHelper = deviceHelper;
+
+            InitializeComponent();
+
+            SetSafeAreaValues();
+        }
+
+        private void SetSafeAreaValues()
+        {
+            var insets = _deviceHelper.GetSafeAreaInsets();
+
+            this[Double_SafeAreaInset_L] = insets.Left;
+            this[Double_SafeAreaInset_T] = insets.Top;
+            this[Double_SafeAreaInset_R] = insets.Right;
+            this[Double_SafeAreaInset_B] = insets.Bottom;
+
+            this[Thickness_SafeArea] = insets;
+
+            this[Thickness_SafeAreaInsets_V] = new Thickness(0, insets.Top, 0, insets.Bottom);
+            this[Thickness_SafeAreaInsets_H] = new Thickness(insets.Left, 0, insets.Right, 0);
+
+            this[Thickness_SafeAreaInsets_L] = new Thickness(insets.Left, 0, 0, 0);
+            this[Thickness_SafeAreaInsets_T] = new Thickness(0, insets.Top, 0, 0);
+            this[Thickness_SafeAreaInsets_R] = new Thickness(0, 0, insets.Right, 0);
+            this[Thickness_SafeAreaInsets_B] = new Thickness(0, 0, 0, insets.Bottom);
+
+            this[Thickness_SafeAreaInsets_LRB] = new Thickness(insets.Left, 0, insets.Right, insets.Bottom);
+        }
+    }
+}

--- a/Library/PhantomLib/Utilities/IDeviceHelper.cs
+++ b/Library/PhantomLib/Utilities/IDeviceHelper.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace PhantomLib.Utilities
+{
+    public interface IDeviceHelper
+    {
+        Thickness GetSafeAreaInsets();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Collection of Xamarin additions that are ready to consume.
 
 # Other helpers included in this library
 * BaseAttachable - Acts as a base class for view-models, with helpers to easily raise `IPropertyChanged` events for properties.
+* Safe Area Insets - Allows adjustment based on the safe area insets of the screen (affected by screen cutouts and software buttons). This is available through the `Values` extension, providing dynamic resources for each dimension (Left, Top, Right, Bottom) and thicknesses with combinations of these dimensions. For example, `Double_SafeAreaInset_T` represents the top inset, `Thickness_SafeAreaInsets` represents the thickness with each inset dimension, and `Thickness_SafeAreaInsets_LRB` incorporates the Left, Right, and Bottom insets but ignores the Top inset.
 
 # Installation
 You must make a call to initialize after `Forms.Init` and before `LoadApplication` in order to use the effects from this library in `AppDelegate.cs` (iOS) and/or `MainActivity.cs` (Android).

--- a/Samples/PhantomLibSamples/App.xaml
+++ b/Samples/PhantomLibSamples/App.xaml
@@ -31,6 +31,7 @@
                 of our views in the app.
                 -->
                 <phantom-extensions:Labels />
+                <phantom-extensions:Values />
                 <phantom-extensions:Views />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/Samples/PhantomLibSamples/MainPage.xaml
+++ b/Samples/PhantomLibSamples/MainPage.xaml
@@ -4,7 +4,7 @@
              xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core" 
              NavigationPage.HasNavigationBar="false"
              x:Class="PhantomLibSamples.MainPage" 
-             Padding="{DynamicResource Thickness_SafeArea}">
+             Padding="{DynamicResource Thickness_SafeAreaInsets}">
     <ContentPage.Content>
         <ScrollView>
             <StackLayout VerticalOptions="CenterAndExpand" Margin="10,0">

--- a/Samples/PhantomLibSamples/MainPage.xaml
+++ b/Samples/PhantomLibSamples/MainPage.xaml
@@ -2,11 +2,9 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core" 
-             xmlns:local="clr-namespace:PhantomLib" 
              NavigationPage.HasNavigationBar="false"
              x:Class="PhantomLibSamples.MainPage" 
-             ios:Page.UseSafeArea="true">
-    
+             Padding="{DynamicResource Thickness_SafeArea}">
     <ContentPage.Content>
         <ScrollView>
             <StackLayout VerticalOptions="CenterAndExpand" Margin="10,0">

--- a/Samples/PhantomLibSamples/UltimateControl/UltimateControlPage.xaml
+++ b/Samples/PhantomLibSamples/UltimateControl/UltimateControlPage.xaml
@@ -9,8 +9,7 @@
              xmlns:behaviors="clr-namespace:PhantomLib.Behaviors;assembly=PhantomLib"
              xmlns:local-vms="clr-namespace:PhantomLibSamples.ViewModels;assembly=PhantomLibSamples"
              x:Class="PhantomLibSamples.UltimateControl.UltimateControlPage"
-             Title="Ultimate Entry"
-             ios:Page.UseSafeArea="true">
+             Title="Ultimate Entry">
     <ContentPage.Resources>
         <ResourceDictionary>
             <Style x:Key="UltimateControl" TargetType="controls:UltimateControl">
@@ -43,7 +42,7 @@
         </ResourceDictionary>
     </ContentPage.Resources>
     <ContentPage.Content>
-        <ScrollView>
+        <ScrollView Padding="{DynamicResource Thickness_SafeAreaInsets_LRB}">
             <StackLayout>
                 <StackLayout VerticalOptions="CenterAndExpand" Margin="10,0">
                     <Label Text="Ultimate Entry" FontSize="Large" />


### PR DESCRIPTION
This PR addresses Issue #4, allowing adjustments based on the safe area insets. This expands on the default implementation provided for iOS devices, allowing more elements to be adjusted than just the page.

One use case is a ScrollView with content taller than the page. Instead of adding padding to the ScrollView's container (page), we can add the padding to the ScrollView itself. This gives a more natural look and feel to the page.

Android handles cutouts differently, so we don't need to do anything special.

<img width="745" alt="Screen Shot 2019-09-06 at 2 01 58 PM" src="https://user-images.githubusercontent.com/1892138/64450549-5e835e80-d0b0-11e9-81c9-c1ea014bb62a.png">
