### PR TITLE
Add Floating Action Button

### DIFF
--- a/Library/PhantomLib/Extensions/Pages.xaml
+++ b/Library/PhantomLib/Extensions/Pages.xaml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ResourceDictionary
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="PhantomLib.Extensions.Pages">
+    
+</ResourceDictionary>

--- a/Library/PhantomLib/Extensions/Pages.xaml.cs
+++ b/Library/PhantomLib/Extensions/Pages.xaml.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using PhantomLib.Templates;
+using Xamarin.Forms;
+
+namespace PhantomLib.Extensions
+{
+    public partial class Pages
+    {
+        public Pages()
+        {
+            InitializeComponent();
+        }
+
+        public static readonly BindableProperty FloatingActionButtonProperty = BindableProperty.CreateAttached(
+            "FloatingActionButton",
+            typeof(Button),
+            typeof(Pages),
+            default(Button),
+            propertyChanged: OnFloatingActionButtonPropertyChanged);
+
+        private static void OnFloatingActionButtonPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            if (!(bindable is ContentPage contentPage))
+                throw new NotSupportedException($"{FloatingActionButtonProperty.PropertyName} may only be set on instances of ContentPage");
+
+            if (!(contentPage.ControlTemplate is FloatingActionButtonControlTemplate template))
+            {
+                contentPage.ControlTemplate = template = new FloatingActionButtonControlTemplate();
+            }
+        }
+
+        public static Button GetFloatingActionButton(BindableObject bindable)
+        {
+            return (Button)bindable.GetValue(FloatingActionButtonProperty);
+        }
+
+        public static void SetFloatingActionButton(BindableObject bindable, Button value)
+        {
+            if (!(bindable is ContentPage))
+                throw new NotSupportedException($"{FloatingActionButtonProperty.PropertyName} may only be set on instances of ContentPage");
+
+            bindable.SetValue(FloatingActionButtonProperty, value);
+        }
+    }
+}

--- a/Library/PhantomLib/PhantomLib.csproj
+++ b/Library/PhantomLib/PhantomLib.csproj
@@ -25,5 +25,6 @@
     <Folder Include="Behaviors\" />
     <Folder Include="Models\" />
     <Folder Include="Converters\" />
+    <Folder Include="Templates\" />
   </ItemGroup>
 </Project>

--- a/Library/PhantomLib/Templates/FloatingActionButtonControlTemplate.cs
+++ b/Library/PhantomLib/Templates/FloatingActionButtonControlTemplate.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using PhantomLib.Extensions;
+using Xamarin.Forms;
+
+namespace PhantomLib.Templates
+{
+    public class FloatingActionButtonControlTemplate : ControlTemplate
+    {
+        public FloatingActionButtonControlTemplate()
+            : base(typeof(Container))
+        {
+            
+        }
+
+        public class Container : Grid
+        {
+            public Container()
+            {
+                Children.Add(new ContentPresenter());
+            }
+
+            private Element _parent;
+            protected override void OnParentSet()
+            {
+                base.OnParentSet();
+
+                if (_parent is INotifyPropertyChanged oldParent)
+                {
+                    oldParent.PropertyChanged -= Parent_PropertyChanged;
+                }
+
+                _parent = Parent;
+
+                if (_parent is INotifyPropertyChanged newParent)
+                {
+                    newParent.PropertyChanged += Parent_PropertyChanged;
+                }
+
+                SetButton();
+            }
+
+            private void Parent_PropertyChanged(object sender, PropertyChangedEventArgs e)
+            {
+                if (e.PropertyName == Pages.FloatingActionButtonProperty.PropertyName)
+                    SetButton();
+            }
+
+            private void SetButton()
+            {
+                Button = Pages.GetFloatingActionButton(Parent);
+            }
+
+            private Button _button;
+            public Button Button
+            {
+                get { return _button; }
+                set
+                {
+                    if (_button != null && Children.Contains(_button))
+                    {
+                        Children.Remove(_button);
+                    }
+
+                    _button = value;
+
+                    if (_button != null && !Children.Contains(_button))
+                    {
+                        Children.Add(_button);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Collection of Xamarin additions that are ready to consume.
 # Attached Properties in this library
 * Labels.Kerning - Helper to easily add Kerning Effect
 * Views.TapBackgroundColor - Set the temporary background color of a view when it is tapped
+* Pages.FloatingActionButton - Add a Button to the page as a floating action button.
 
 # Other helpers included in this library
 * BaseAttachable - Acts as a base class for view-models, with helpers to easily raise `IPropertyChanged` events for properties.

--- a/Samples/PhantomLibSamples/FloatingActionButton/FloatingActionButtonPage.xaml
+++ b/Samples/PhantomLibSamples/FloatingActionButton/FloatingActionButtonPage.xaml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+    xmlns:android="clr-namespace:Xamarin.Forms.PlatformConfiguration.AndroidSpecific;assembly=Xamarin.Forms.Core"
+    xmlns:extensions="clr-namespace:PhantomLib.Extensions;assembly=PhantomLib"
+    x:Class="PhantomLibSamples.FloatingActionButton.FloatingActionButtonPage"
+    Title="FAB Example"
+    ios:Page.UseSafeArea="true">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Style x:Key="Button_FloatingAction" TargetType="Button">
+                <Setter Property="HorizontalOptions" Value="End" />
+                <Setter Property="VerticalOptions" Value="End" />
+                <Setter Property="Margin" Value="0, 0, 20, 20" />
+                <Setter Property="WidthRequest" Value="56" />
+                <Setter Property="HeightRequest" Value="56" />
+                <Setter Property="CornerRadius" Value="28" />
+                <Setter Property="ios:VisualElement.IsShadowEnabled" Value="true" />
+                <Setter Property="ios:VisualElement.ShadowColor" Value="Black" />
+                <Setter Property="ios:VisualElement.ShadowOpacity" Value="0.5" />
+                <Setter Property="ios:VisualElement.ShadowRadius" Value="4" />
+                <Setter Property="ios:VisualElement.ShadowOffset" Value="0, 2" />
+                <Setter Property="android:Button.UseDefaultShadow" Value="true" />
+                <Setter Property="android:Button.UseDefaultPadding" Value="true" />
+            </Style>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <extensions:Pages.FloatingActionButton>
+        <Button ImageSource="icon_lock_open.png" Style="{StaticResource Button_FloatingAction}" BackgroundColor="#FF4081" Clicked="OnClicked" />
+    </extensions:Pages.FloatingActionButton>
+    <ContentPage.Content>
+        <ScrollView>
+            <Label x:Name="_lblText" Text="Click the Floating Action Button to append a randomly-generated string to this label." />
+        </ScrollView>
+    </ContentPage.Content>
+</ContentPage>

--- a/Samples/PhantomLibSamples/FloatingActionButton/FloatingActionButtonPage.xaml.cs
+++ b/Samples/PhantomLibSamples/FloatingActionButton/FloatingActionButtonPage.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms;
+
+namespace PhantomLibSamples.FloatingActionButton
+{
+    public partial class FloatingActionButtonPage
+    {
+        private readonly Random _random;
+
+        public FloatingActionButtonPage()
+        {
+            _random = new Random();
+
+            InitializeComponent();
+        }
+
+        private void OnClicked(object sender, EventArgs e)
+        {
+            var newText = GenerateRandomString();
+            _lblText.Text += newText;
+        }
+
+        private string GenerateRandomString(int length = 256)
+        {
+            var buffer = new byte[length];
+            _random.NextBytes(buffer);
+
+            return $"\n\n{Convert.ToBase64String(buffer)}";
+        }
+    }
+}

--- a/Samples/PhantomLibSamples/MainPage.xaml
+++ b/Samples/PhantomLibSamples/MainPage.xaml
@@ -13,6 +13,7 @@
                 <Button Text="UltimateControl Examples" Clicked="Handle_Clicked" />
                 <Button Text="Effects Examples" Clicked="Handle_Clicked_1" />
                 <Button Text="Converters Examples" Clicked="Handle_Clicked_2" />
+                <Button Text="Floating Action Button" Clicked="Handle_Clicked_FloatingActionButton" />
                 <Button Text="Misc" Clicked="Handle_Clicked_3" />
                 
             </StackLayout>

--- a/Samples/PhantomLibSamples/MainPage.xaml.cs
+++ b/Samples/PhantomLibSamples/MainPage.xaml.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using PhantomLib.CustomControls;
 using PhantomLibSamples.Converters;
 using PhantomLibSamples.Effects;
+using PhantomLibSamples.FloatingActionButton;
 using PhantomLibSamples.Misc;
 using PhantomLibSamples.UltimateControl;
 using PhantomLibSamples.Utilities;
@@ -49,6 +50,11 @@ namespace PhantomLibSamples
             page.BindingContext = new ConvertersViewModel();
 
             await Navigation.PushAsync(page);
+        }
+
+        async void Handle_Clicked_FloatingActionButton(object sender, System.EventArgs e)
+        {
+            await Navigation.PushAsync(new FloatingActionButtonPage());
         }
 
         async void Handle_Clicked_3(object sender, System.EventArgs e)

--- a/Samples/PhantomLibSamples/PhantomLibSamples.csproj
+++ b/Samples/PhantomLibSamples/PhantomLibSamples.csproj
@@ -25,6 +25,7 @@
     <Folder Include="Effects\" />
     <Folder Include="Converters\" />
     <Folder Include="Misc\" />
+    <Folder Include="FloatingActionButton\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Effects\EffectsPage.xaml.cs">


### PR DESCRIPTION
This PR addresses #8 to allow developers to set a `Button` up as a floating action button. To do this, the dev can use the `Pages.FloatingActionButton` attached property on a `ContentPage`. Behind the scenes, we will set the `ControlTemplate` to render the button on top of the page's content.

![Simulator Screen Shot - iPhone Xʀ - 2019-09-09 at 15 50 26](https://user-images.githubusercontent.com/1892138/64562249-95f54380-d31a-11e9-801d-a9b5d84b005f.png)
![Screenshot_1568058424](https://user-images.githubusercontent.com/1892138/64562254-98579d80-d31a-11e9-8828-485a1bf6b29e.png)
