### PR TITLE
Disabling animations

### DIFF
--- a/Library/PhantomLib.Droid/PhantomLib.Droid.csproj
+++ b/Library/PhantomLib.Droid/PhantomLib.Droid.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Renderers\UltimateEntryRenderer.cs" />
     <Compile Include="Effects\TintImageEffect.cs" />
     <Compile Include="Utilities\DeviceHelper.cs" />
+    <Compile Include="Services\AnimationsService.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
@@ -70,6 +71,7 @@
     <Folder Include="Effects\" />
     <Folder Include="Renderers\" />
     <Folder Include="Utilities\" />
+    <Folder Include="Services\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PhantomLib\PhantomLib.csproj">

--- a/Library/PhantomLib.Droid/PhantomLib.Droid.csproj
+++ b/Library/PhantomLib.Droid/PhantomLib.Droid.csproj
@@ -15,7 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Library/PhantomLib.Droid/Services/AnimationsService.cs
+++ b/Library/PhantomLib.Droid/Services/AnimationsService.cs
@@ -1,0 +1,38 @@
+﻿using Android.Content;
+using Android.OS;
+using PhantomLib.Droid.Services;
+using PhantomLib.Services;
+using Xamarin.Forms;
+
+[assembly: Dependency(typeof(AnimationsService))]
+namespace PhantomLib.Droid.Services
+{
+    public class AnimationsService : IAnimationsService
+    {
+
+        public bool AnimationsEnabled()
+        {
+            float animatorSpeed;
+            ContentResolver resolver = Android.App.Application.Context?.ContentResolver;
+
+
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1)
+            {
+                animatorSpeed = Android.Provider.Settings.Global.GetFloat(
+                         resolver,
+                        Android.Provider.Settings.Global.AnimatorDurationScale,
+                        0);
+            }
+            else
+            {
+                animatorSpeed = Android.Provider.Settings.System.GetFloat(
+                        resolver,
+#pragma warning disable CS0618 // Type or member is obsolete
+                        Android.Provider.Settings.System.AnimatorDurationScale,
+#pragma warning restore CS0618 // Type or member is obsolete
+                        0);
+            }
+            return animatorSpeed > 0;
+        }
+    }
+}

--- a/Library/PhantomLib.iOS/PhantomLib.iOS.csproj
+++ b/Library/PhantomLib.iOS/PhantomLib.iOS.csproj
@@ -57,6 +57,7 @@
     <Folder Include="Effects\" />
     <Folder Include="Renderers\" />
     <Folder Include="Utilities\" />
+    <Folder Include="Services\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -66,6 +67,7 @@
     <Compile Include="Renderers\UltimateEntryRenderer.cs" />
     <Compile Include="Effects\TintImageEffect.cs" />
     <Compile Include="Utilities\DeviceHelper.cs" />
+    <Compile Include="Services\AnimationsService.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PhantomLib\PhantomLib.csproj">

--- a/Library/PhantomLib.iOS/Services/AnimationsService.cs
+++ b/Library/PhantomLib.iOS/Services/AnimationsService.cs
@@ -1,0 +1,16 @@
+﻿using PhantomLib.iOS.Services;
+using PhantomLib.Services;
+using Xamarin.Forms;
+
+[assembly: Dependency(typeof(AnimationsService))]
+namespace PhantomLib.iOS.Services
+{
+    public class AnimationsService : IAnimationsService
+    {
+        public bool AnimationsEnabled()
+        {
+            //iOS doesn't currently support disabling of animations
+            return true;
+        }
+    }
+}

--- a/Library/PhantomLib/CustomControls/FloatingLabel.xaml.cs
+++ b/Library/PhantomLib/CustomControls/FloatingLabel.xaml.cs
@@ -7,6 +7,9 @@ namespace PhantomLib.CustomControls
 {
     public partial class FloatingLabel : Grid
     {
+
+        private readonly double EPSILON = 0.0001;
+
         // Attached property to map an ultimate entry to this control.
         public static BindableProperty AttachedEntryProperty =
             BindableProperty.CreateAttached("AttachedEntry", typeof(UltimateEntry), typeof(FloatingLabel), null, propertyChanged: HandleEntryChanged);
@@ -178,17 +181,37 @@ namespace PhantomLib.CustomControls
         {
             int floatingTransitionHeight = FloatingPlaceholderFontSize - FloatingTopMargin;
 
-            var textTranslationAnimation = Label.TranslateTo(FloatingLeftMargin, 0 - floatingTransitionHeight); 
+            var textTranslationAnimation = Label.TranslateTo(FloatingLeftMargin, 0 - floatingTransitionHeight);
             var textResizeAnimation = SizeTo(FloatingFontSize);
-            await Task.WhenAll(textTranslationAnimation, textResizeAnimation);
             
+
+            await Task.WhenAll(textTranslationAnimation, textResizeAnimation);
+
+            //Handle the scenario of animations being disabled or failing
+            if (Label.TranslationY >= 0)
+            {
+                Label.TranslationY = 0 - floatingTransitionHeight;
+                Label.TranslationX = FloatingLeftMargin;
+                Label.FontSize = FloatingFontSize;
+
+            }
         }
 
         private async Task TransitionToPlaceholder(bool animated = true)
         {
             var transition1 = Label.TranslateTo(FloatingLeftMargin, 0);
             var transition2 = SizeTo(FloatingPlaceholderFontSize);
+
+
             await Task.WhenAll(transition1, transition2);
+
+            //Handle the scenario of animations being disabled or failing
+            if (Math.Abs(Label.TranslationY) > EPSILON)
+            {
+                Label.TranslationY = 0;
+                Label.TranslationX = FloatingLeftMargin;
+                Label.FontSize = FloatingPlaceholderFontSize;
+            }
         }
 
         private Task SizeTo(int fontSize)

--- a/Library/PhantomLib/CustomControls/FloatingLabel.xaml.cs
+++ b/Library/PhantomLib/CustomControls/FloatingLabel.xaml.cs
@@ -8,9 +8,6 @@ namespace PhantomLib.CustomControls
 {
     public partial class FloatingLabel : Grid
     {
-
-        private readonly double EPSILON = 0.0001;
-
         // Attached property to map an ultimate entry to this control.
         public static BindableProperty AttachedEntryProperty =
             BindableProperty.CreateAttached("AttachedEntry", typeof(UltimateEntry), typeof(FloatingLabel), null, propertyChanged: HandleEntryChanged);
@@ -41,6 +38,9 @@ namespace PhantomLib.CustomControls
                 ue.HideBackgroundColor = true;
 
                 ue.EntryFocusChanged += floatingLabel._ultimateEntry_EntryFocusChanged; // _ultimateEntry_EntryFocusChanged;
+
+                // This is needed to initially put the placeholder label in the correct spot.
+                floatingLabel.Label.TranslationX = floatingLabel.FloatingLeftMargin;
 
                 // Set the left on ThicknessPadding so that the text in the entry is always
                 // left aligned to the floating label.

--- a/Library/PhantomLib/PhantomLib.csproj
+++ b/Library/PhantomLib/PhantomLib.csproj
@@ -27,5 +27,6 @@
     <Folder Include="Converters\" />
     <Folder Include="Templates\" />
     <Folder Include="CustomControls\Enums\" />
+    <Folder Include="Services\" />
   </ItemGroup>
 </Project>

--- a/Library/PhantomLib/Services/IAnimationsService.cs
+++ b/Library/PhantomLib/Services/IAnimationsService.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace PhantomLib.Services
+{
+    public interface IAnimationsService
+    {
+        bool AnimationsEnabled();
+    }
+}

--- a/Samples/PhantomLibSamples.Android/PhantomLibSamples.Android.csproj
+++ b/Samples/PhantomLibSamples.Android/PhantomLibSamples.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>

--- a/Samples/PhantomLibSamples.Android/Properties/AndroidManifest.xml
+++ b/Samples/PhantomLibSamples.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.ost.phantomlibsamples">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="27" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
 	<application android:label="PhantomLibSamples.Android"></application>
 </manifest>


### PR DESCRIPTION
If the user has disabled animations the translate and text sizing on the floating label do not work.  This addresses that issue.