### PR TITLE
Float label if text is added via bindings

### DIFF
--- a/Library/PhantomLib.Droid/PhantomLib.Droid.csproj
+++ b/Library/PhantomLib.Droid/PhantomLib.Droid.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Xamarin.Forms.4.3.0.991221\build\Xamarin.Forms.props" Condition="Exists('..\..\packages\Xamarin.Forms.4.3.0.991221\build\Xamarin.Forms.props')" />
+  <Import Project="..\..\packages\Xamarin.Forms.4.2.0.709249\build\Xamarin.Forms.props" Condition="Exists('..\..\packages\Xamarin.Forms.4.2.0.709249\build\Xamarin.Forms.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -157,19 +157,19 @@
       <HintPath>..\..\packages\Xamarin.Android.Support.Design.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.Design.dll</HintPath>
     </Reference>
     <Reference Include="FormsViewGroup">
-      <HintPath>..\..\packages\Xamarin.Forms.4.3.0.991221\lib\MonoAndroid90\FormsViewGroup.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.4.2.0.709249\lib\MonoAndroid90\FormsViewGroup.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.4.3.0.991221\lib\MonoAndroid90\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.4.2.0.709249\lib\MonoAndroid90\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.Android">
-      <HintPath>..\..\packages\Xamarin.Forms.4.3.0.991221\lib\MonoAndroid90\Xamarin.Forms.Platform.Android.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.4.2.0.709249\lib\MonoAndroid90\Xamarin.Forms.Platform.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.4.3.0.991221\lib\MonoAndroid90\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.4.2.0.709249\lib\MonoAndroid90\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.4.3.0.991221\lib\MonoAndroid90\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.4.2.0.709249\lib\MonoAndroid90\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -250,5 +250,5 @@
   <Import Project="..\..\packages\Xamarin.Android.Support.v7.AppCompat.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.v7.AppCompat.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v7.AppCompat.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.v7.AppCompat.targets')" />
   <Import Project="..\..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.targets')" />
   <Import Project="..\..\packages\Xamarin.Android.Support.Design.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Design.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Design.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Design.targets')" />
-  <Import Project="..\..\packages\Xamarin.Forms.4.3.0.991221\build\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.4.3.0.991221\build\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.4.2.0.709249\build\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.4.2.0.709249\build\Xamarin.Forms.targets')" />
 </Project>

--- a/Library/PhantomLib.Droid/packages.config
+++ b/Library/PhantomLib.Droid/packages.config
@@ -37,5 +37,5 @@
   <package id="Xamarin.Android.Support.Vector.Drawable" version="28.0.0.3" targetFramework="monoandroid10.0" />
   <package id="Xamarin.Android.Support.VersionedParcelable" version="28.0.0.3" targetFramework="monoandroid10.0" />
   <package id="Xamarin.Android.Support.ViewPager" version="28.0.0.3" targetFramework="monoandroid10.0" />
-  <package id="Xamarin.Forms" version="4.3.0.991221" targetFramework="monoandroid10.0" />
+  <package id="Xamarin.Forms" version="4.2.0.709249" targetFramework="monoandroid10.0" />
 </packages>

--- a/Library/PhantomLib.iOS/PhantomLib.iOS.csproj
+++ b/Library/PhantomLib.iOS/PhantomLib.iOS.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Xamarin.Forms.4.3.0.991211\build\Xamarin.Forms.props" Condition="Exists('..\..\packages\Xamarin.Forms.4.3.0.991211\build\Xamarin.Forms.props')" />
+  <Import Project="..\..\packages\Xamarin.Forms.4.2.0.709249\build\Xamarin.Forms.props" Condition="Exists('..\..\packages\Xamarin.Forms.4.2.0.709249\build\Xamarin.Forms.props')" />
   <Import Project="..\packages\Xamarin.Forms.4.0.0.482894\build\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.4.0.0.482894\build\Xamarin.Forms.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,16 +40,16 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.4.3.0.991211\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.4.2.0.709249\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.4.3.0.991211\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.4.2.0.709249\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS">
-      <HintPath>..\..\packages\Xamarin.Forms.4.3.0.991211\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.4.2.0.709249\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.4.3.0.991211\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.4.2.0.709249\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -80,5 +80,5 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Forms.4.0.0.482894\build\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.4.0.0.482894\build\Xamarin.Forms.targets')" />
-  <Import Project="..\..\packages\Xamarin.Forms.4.3.0.991211\build\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.4.3.0.991211\build\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.4.2.0.709249\build\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.4.2.0.709249\build\Xamarin.Forms.targets')" />
 </Project>

--- a/Library/PhantomLib.iOS/packages.config
+++ b/Library/PhantomLib.iOS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="4.3.0.991211" targetFramework="xamarinios10" />
+  <package id="Xamarin.Forms" version="4.2.0.709249" targetFramework="xamarinios10" />
 </packages>

--- a/Library/PhantomLib/CustomControls/FloatingLabel.xaml.cs
+++ b/Library/PhantomLib/CustomControls/FloatingLabel.xaml.cs
@@ -22,6 +22,7 @@ namespace PhantomLib.CustomControls
                 if (oldValue != null && oldValue is UltimateEntry oldEntry)
                 {
                     oldEntry.EntryFocusChanged -= floatingLabel._ultimateEntry_EntryFocusChanged;
+                    oldEntry.TextChanged -= floatingLabel._ultimateEntry_TextChanged;
                 }
 
                 // If the entry already has text, float the label.
@@ -37,12 +38,22 @@ namespace PhantomLib.CustomControls
 
                 ue.EntryFocusChanged += floatingLabel._ultimateEntry_EntryFocusChanged; // _ultimateEntry_EntryFocusChanged;
 
+                ue.TextChanged += floatingLabel._ultimateEntry_TextChanged;
+
                 // This is needed to initially put the placeholder label in the correct location.
                 floatingLabel.Label.TranslationX = floatingLabel.FloatingLeftMargin;
 
                 // Set the left on ThicknessPadding so that the text in the entry is always
                 // left aligned to the floating label.
                 ue.ThicknessPadding = new Thickness(floatingLabel.FloatingLeftMargin, ue.ThicknessPadding.Top, ue.ThicknessPadding.Right, ue.ThicknessPadding.Bottom);
+            }
+        }
+
+        private void _ultimateEntry_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if(!string.IsNullOrEmpty(e.NewTextValue))
+            {
+                AnimatePlaceholder((UltimateEntry)sender);
             }
         }
 

--- a/Library/PhantomLib/CustomControls/FloatingLabel.xaml.cs
+++ b/Library/PhantomLib/CustomControls/FloatingLabel.xaml.cs
@@ -51,10 +51,18 @@ namespace PhantomLib.CustomControls
 
         private void _ultimateEntry_TextChanged(object sender, TextChangedEventArgs e)
         {
-            //if the label is not floating and the entry has text, float it
-            if(!string.IsNullOrEmpty(e.NewTextValue) && !IsFloating)
+            if (sender is UltimateEntry ue)
             {
-                AnimatePlaceholder((UltimateEntry)sender);
+                //if the label is not floating and the entry has text, float it
+                if (!string.IsNullOrEmpty(e.NewTextValue) && !IsFloating)
+                {
+                    AnimatePlaceholder(ue);
+                }
+                else if (string.IsNullOrEmpty(e.NewTextValue) && IsFloating)
+                {
+                    // if the entry was floating but now has no text, unfloat it.
+                    AnimatePlaceholder((ue));
+                }
             }
         }
 

--- a/Library/PhantomLib/CustomControls/FloatingLabel.xaml.cs
+++ b/Library/PhantomLib/CustomControls/FloatingLabel.xaml.cs
@@ -36,7 +36,7 @@ namespace PhantomLib.CustomControls
                 ue.BackgroundColor = floatingLabel.BackgroundColor;
                 ue.HideBackgroundColor = true;
 
-                ue.EntryFocusChanged += floatingLabel._ultimateEntry_EntryFocusChanged; // _ultimateEntry_EntryFocusChanged;
+                ue.EntryFocusChanged += floatingLabel._ultimateEntry_EntryFocusChanged; 
 
                 ue.TextChanged += floatingLabel._ultimateEntry_TextChanged;
 

--- a/Library/PhantomLib/CustomControls/FloatingLabel.xaml.cs
+++ b/Library/PhantomLib/CustomControls/FloatingLabel.xaml.cs
@@ -51,7 +51,8 @@ namespace PhantomLib.CustomControls
 
         private void _ultimateEntry_TextChanged(object sender, TextChangedEventArgs e)
         {
-            if(!string.IsNullOrEmpty(e.NewTextValue))
+            //if the label is not floating and the entry has text, float it
+            if(!string.IsNullOrEmpty(e.NewTextValue) && !IsFloating)
             {
                 AnimatePlaceholder((UltimateEntry)sender);
             }

--- a/Library/PhantomLib/PhantomLib.csproj
+++ b/Library/PhantomLib/PhantomLib.csproj
@@ -15,7 +15,7 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.3.0.991211" />
+    <PackageReference Include="Xamarin.Forms" Version="4.2.0.709249" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Effects\" />

--- a/Samples/PhantomLibSample.iOS/PhantomLibSamples.iOS.csproj
+++ b/Samples/PhantomLibSample.iOS/PhantomLibSamples.iOS.csproj
@@ -162,7 +162,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.3.0.991211" />
+    <PackageReference Include="Xamarin.Forms" Version="4.2.0.709249" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>

--- a/Samples/PhantomLibSamples.Android/PhantomLibSamples.Android.csproj
+++ b/Samples/PhantomLibSamples.Android/PhantomLibSamples.Android.csproj
@@ -52,7 +52,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.3.0.991211" />
+    <PackageReference Include="Xamarin.Forms" Version="4.2.0.709249" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.3" />

--- a/Samples/PhantomLibSamples/PhantomLibSamples.csproj
+++ b/Samples/PhantomLibSamples/PhantomLibSamples.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.3.0.991211" />
+    <PackageReference Include="Xamarin.Forms" Version="4.2.0.709249" />
     <PackageReference Include="LiveXAML" Version="2.1.73" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
When text is added via bindings the label was not floating resulting in an overlapping label and text.  
<img width="215" alt="Screen Shot 2019-12-12 at 9 28 13 AM" src="https://user-images.githubusercontent.com/6330499/70720465-da013700-1cc1-11ea-913f-19cad79b2547.png">


This change fixes that scenario.