### PR TITLE
Xamarin.Forms 4.6+ Startup Crash

### DIFF
--- a/Library/PhantomLib.nuspec
+++ b/Library/PhantomLib.nuspec
@@ -26,13 +26,16 @@
     <file src="PhantomLib\bin\Release\netstandard2.0\PhantomLib.pdb"	target="lib\netstandard2.0\PhantomLib.pdb" />
 
     <!-- iOS -->
-    <file src="PhantomLib.iOS\bin\Release\*.dll"		    target="lib\Xamarin.iOS10" />
-    <file src="PhantomLib.iOS\bin\Release\*.pdb"		    target="lib\Xamarin.iOS10" />
-    
+    <file src="PhantomLib.iOS\bin\Release\PhantomLib.dll" target="lib\Xamarin.iOS10" />
+    <file src="PhantomLib.iOS\bin\Release\PhantomLib.pdb" target="lib\Xamarin.iOS10" />
+    <file src="PhantomLib.iOS\bin\Release\PhantomLib.iOS.dll" target="lib\Xamarin.iOS10" />
+    <file src="PhantomLib.iOS\bin\Release\PhantomLib.iOS.pdb"	target="lib\Xamarin.iOS10" />
+
     <!-- Android -->
-    <file src="PhantomLib.Droid\bin\Release\*.dll"	target="lib\MonoAndroid10" />
-    <file src="PhantomLib.Droid\bin\Release\*.pdb"	target="lib\MonoAndroid10" />
-    
+    <file src="PhantomLib.Droid\bin\Release\PhantomLib.dll"	target="lib\MonoAndroid10" />
+    <file src="PhantomLib.Droid\bin\Release\PhantomLib.pdb"	target="lib\MonoAndroid10" />
+    <file src="PhantomLib.Droid\bin\Release\PhantomLib.Droid.dll"	target="lib\MonoAndroid10" />
+    <file src="PhantomLib.Droid\bin\Release\PhantomLib.Droid.pdb"	target="lib\MonoAndroid10" />
 
     <!-- Readme -->
     <file src="readme.txt" target="" />


### PR DESCRIPTION
I was seeing `VTable setup of type Xamarin.Forms.Forms+IOSPlatformServices failed` on startup when Xamarin.Forms was 4.6+. Saw a similar bug [here](https://github.com/xamarin/Xamarin.Forms/issues/10785), but it looks like we were accidentally including Xamarin.Forms in the publish package.

